### PR TITLE
Add PyPI release tooling and date-based tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install build dependencies
+        run: pip install hatch hatch-vcs twine
+      - name: Build
+        run: hatch build
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload -u __token__ -p "$PYPI_TOKEN" dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,11 @@ repos:
       - id: mypy
         args: [--install-types, --non-interactive]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.241
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.8
     hooks:
       - id: ruff
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ MAKE_TESTS ?= ""
 MAKE_PYTEST_ARGS ?=
 
 # Targets
-.PHONY: auth setup start fetch clean build install uninstall full stop test
+.PHONY: auth setup start fetch clean build release install uninstall full stop test
 
 test:
 	pytest --capture=tee-sys ${MAKE_PYTEST_ARGS} ${MAKE_TESTS}
@@ -63,8 +63,12 @@ clean:
 	@rm -rf $(PROJECT_NAME).egg-info
 
 build: clean
-	@echo "Building the project..."
-	@hatch build
+        @echo "Building the project..."
+        @hatch build
+
+release:
+        @echo "Creating version tag and pushing to origin..."
+        @python scripts/release.py
 
 uninstall:
 	@echo "Uninstalling the project..."

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [API Endpoints](#api-endpoints)
 - [Development](#development)
   - [Testing](#testing)
+- [Releasing](#releasing)
 - [License](#license)
 
 ## Installation
@@ -144,6 +145,19 @@ make full
 ```bash
 make test
 ```
+
+### Releasing
+
+The project uses calendar-based version tags in the form `v<dd.mm.yy>.<n>` where `n` is the release number for the day. To
+cut a new release:
+
+```bash
+make release
+```
+
+This command updates the version, creates a tag and pushes it to GitHub. A
+workflow then builds the project and uploads the artifacts to PyPI using the
+repository's `PYPI_TOKEN` secret.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,14 @@ dev = [
     "coverage",
     "pytest-mock",
     "hatch-vcs",
+    "types-requests",
+    "types-cachetools",
 ]
 
 build = [
-  "hatch-vcs"
+  "hatch",
+  "hatch-vcs",
+  "twine",
 ]
 
 [project.urls]
@@ -54,8 +58,10 @@ Issues = "https://github.com/qatoolist/vaultutils/issues"
 Source = "https://github.com/qatoolist/vaultutils"
 
 [tool.hatch.version]
-raw-options.version_scheme = "calver-by-date"
-source="vcs"
+tag-pattern = "^v(?P<version>\\d{2}\\.\\d{2}\\.\\d{2}\\.\\d+)$"
+source = "vcs"
+raw-options.version_scheme = "no-guess-dev"
+raw-options.local_scheme = "no-local-version"
 
 [tool.hatch.envs.types]
 extra-dependencies = [
@@ -127,6 +133,8 @@ target-version = ['py38']
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -154,18 +162,18 @@ select = [
   "W",
   "YTT",
 ]
-ignore = ["E501", "PLW0602", "PLW0603", "B904", "S603", "S607", ]
+ignore = ["E501", "PLW0602", "PLW0603", "B904", "S603", "S607"]
 unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["vaultutils"]
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Release utility for vaultutils.
+
+This script creates a date-based version tag and pushes it to the repository.
+Versions follow the scheme ``v<dd.mm.yy>.<n>`` where ``n`` is the incrementing
+release number for that day. A separate GitHub workflow builds the project and
+uploads it to PyPI whenever such a tag is pushed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+import subprocess
+from pathlib import Path
+
+TAG_PATTERN = r"^v\d{2}\.\d{2}\.\d{2}\.\d+$"
+VERSION_FILE = Path("src/vaultutils/__about__.py")
+
+
+def compute_tag() -> tuple[str, str]:
+    today = _dt.datetime.now(tz=_dt.UTC).date()
+    date_str = today.strftime("%d.%m.%y")
+    prefix = f"v{date_str}."
+
+    tags = subprocess.check_output(["git", "tag"], text=True).splitlines()
+    pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
+    numbers = [int(m.group(1)) for t in tags if (m := pattern.match(t))]
+    next_num = max(numbers, default=0) + 1
+    tag = f"{prefix}{next_num}"
+    version = f"{date_str}.{next_num}"
+    return tag, version
+
+
+def write_version(version: str) -> None:
+    VERSION_FILE.write_text(f'__version__ = "{version}"\n')
+
+
+def run(*cmd: str) -> None:
+    subprocess.check_call(cmd)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    tag, version = compute_tag()
+    logging.info("Releasing %s as %s", version, tag)
+    write_version(version)
+    run("git", "commit", "-am", f"chore: release {tag}")
+    run("git", "tag", tag)
+    run("git", "push", "origin", "HEAD", tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vaultutils/auth.py
+++ b/src/vaultutils/auth.py
@@ -71,7 +71,7 @@ def get_oidc_token(client: Client, oidc_callback_port: int = 8250) -> str:
             error_msg: str = "Authorization URL is empty"
             raise ValueError(error_msg)
     except Exception as error:
-        error_msg: str = f"Error while getting OIDC authorization URL: {error}"
+        error_msg = f"Error while getting OIDC authorization URL: {error}"
         raise ValueError(error_msg)
 
     logging.info(f"Authorization URL: {auth_url}")
@@ -91,11 +91,12 @@ def get_oidc_token(client: Client, oidc_callback_port: int = 8250) -> str:
     if Config.VAULT_OIDC_HEADLESS:
         time.sleep(3)
         try:
-            from playwright.sync_api import sync_playwright  # type: ignore
+            from playwright.sync_api import (  # type: ignore  # noqa: PLC0415
+                sync_playwright,
+            )
         except ModuleNotFoundError as exc:
-            raise RuntimeError(
-                "Playwright is required for headless OIDC authentication"
-            ) from exc
+            msg = "Playwright is required for headless OIDC authentication"
+            raise RuntimeError(msg) from exc
 
         with sync_playwright() as playwright:
             browser = playwright.firefox.launch(
@@ -130,7 +131,7 @@ def _start_local_http_server(oidc_callback_port: int, token_holder: List[Any]) -
     class AuthHandler(BaseHTTPRequestHandler):
         token: str = ""
 
-        def do_GET(self):  # noqa: N802
+        def do_GET(self):
             params = urllib.parse.parse_qs(self.path.split("?")[1])
             self.server.token = params["code"][0]
             token_holder.append(self.server.token)
@@ -166,11 +167,11 @@ def login_vault(client: Client) -> None:
             role_id=Config.VAULT_ROLE_ID, secret_id=Config.VAULT_SECRET_ID
         )
     else:
-        err_msg: str = "No valid authentication method found."
+        err_msg = "No valid authentication method found."
         raise ValueError(err_msg)
 
     if not client.is_authenticated():
-        err_msg: str = "Vault authentication failed"
+        err_msg = "Vault authentication failed"
         raise exceptions.VaultError(err_msg)
 
     store_token(client.token)

--- a/src/vaultutils/client.py
+++ b/src/vaultutils/client.py
@@ -25,7 +25,7 @@ class VaultManagerClient:
 
     def authenticate(self) -> str:
         """Authenticate with Vault using environment variables."""
-        response = requests.post(f"{self.base_url}/authenticate")
+        response = requests.post(f"{self.base_url}/authenticate", timeout=10)
         if response.status_code == HTTPStatus.OK:
             return response.json()["token"]
         else:
@@ -37,6 +37,6 @@ class VaultManagerClient:
     def fetch_secret(self, path: str, key: Optional[str] = None) -> dict[str, Any]:
         """Fetch a secret from Vault."""
         response = requests.post(
-            f"{self.base_url}/fetch-secret", json={"path": path, "key": key}
+            f"{self.base_url}/fetch-secret", json={"path": path, "key": key}, timeout=10
         )
         return response.json()

--- a/src/vaultutils/server.py
+++ b/src/vaultutils/server.py
@@ -23,7 +23,7 @@ def stop_server() -> None:
     host = Config.VAULT_SERVER_HOST
     port = Config.VAULT_SERVER_PORT
     try:
-        response = requests.post(f"http://{host}:{port}/shutdown")
+        response = requests.post(f"http://{host}:{port}/shutdown", timeout=10)
         if response.status_code == HTTPStatus.OK:
             logging.info("Server shutdown successfully.")
     except requests.exceptions.RequestException as e:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,9 +40,9 @@ def test_fetch_secret(runner: CliRunner, mocker) -> None:
     result = runner.invoke(cli, ["fetch-secret", "path/to/secret", "key"])
 
     # Check for exit code and output
-    assert (
-        result.exit_code == 0
-    ), f"Unexpected exit code: {result.exit_code}, output: {result.output}"
+    assert result.exit_code == 0, (
+        f"Unexpected exit code: {result.exit_code}, output: {result.output}"
+    )
     assert "key" in result.output
     assert "value" in result.output
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,7 +36,7 @@ def test_authenticate(mocker, client):
 
     token = client.authenticate()
     assert token == "test_token"  # noqa: S105
-    mock_post.assert_called_once_with("http://localhost:8001/authenticate")
+    mock_post.assert_called_once_with("http://localhost:8001/authenticate", timeout=10)
 
 
 def test_fetch_secret(mocker, client):
@@ -49,4 +49,5 @@ def test_fetch_secret(mocker, client):
     mock_post.assert_called_once_with(
         "http://localhost:8001/fetch-secret",
         json={"path": "path/to/secret", "key": "key"},
+        timeout=10,
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,14 +3,13 @@ from unittest.mock import MagicMock, patch  # noqa: F401
 
 import pytest  # type: ignore
 
-from vaultutils.server import start_server, stop_server  # type: ignore
+from vaultutils.server import app as flask_app  # type: ignore
+from vaultutils.server import start_server, stop_server
 
 
 @pytest.fixture
 def app():
-    from vaultutils.server import app
-
-    return app
+    return flask_app
 
 
 @pytest.fixture
@@ -30,7 +29,7 @@ def test_stop_server(mocker):
     mock_post = mocker.patch("requests.post")
     mock_post.return_value.status_code = HTTPStatus.OK
     stop_server()
-    mock_post.assert_called_once_with("http://localhost:8001/shutdown")
+    mock_post.assert_called_once_with("http://localhost:8001/shutdown", timeout=10)
 
 
 def test_authenticate(mocker, client):


### PR DESCRIPTION
## Summary
- add release helper script to tag by date and upload to PyPI
- wire up `release` make target and document release process
- configure build extras and hatch versioning to use `v<dd.mm.yy>.<n>` tags
- add GitHub workflow to build and publish to PyPI on tagged commits
- modernize lint configuration, add request timeouts, and clean up release script logging

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c8b5a3b883309781f1658ed9f35a